### PR TITLE
Saving on habit toggle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,6 +143,7 @@ fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> color_eyre:
                                 }
                                 app.habits[index].toggle_complete();
                             }
+                            app.save_habits().unwrap();
                         }
                         KeyCode::Char('d') => {
                             if !app.counter.switch && app.counter.build_counter > 0 {


### PR DESCRIPTION
I like to leave apps like this running on my main screen. Unfortunately, since it only saves on quit, if there is a crash (for instance, a power surge) I lose the tracked things.

This adds a config save on toggle to at least save the habits then. It might be worth adding this to every 'action' that edits the state.