### PR TITLE
feat: reminder notifcation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +177,28 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bumpalo"
@@ -83,7 +248,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -101,6 +266,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +288,24 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cron"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "phf",
+ "winnow 0.7.11",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -143,7 +335,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.0.7",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -194,6 +386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +433,17 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -251,6 +462,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,19 +501,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "flow_state"
 version = "1.0.4"
 dependencies = [
  "chrono",
+ "cron",
  "crossterm 0.29.0",
  "dirs",
+ "notify-rust",
  "ratatui",
  "serde",
  "toml",
+ "zbus",
 ]
 
 [[package]]
@@ -291,6 +559,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +592,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -313,10 +619,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -343,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,12 +680,14 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -403,10 +735,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.172"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
@@ -426,9 +764,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -458,7 +796,19 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
 ]
 
 [[package]]
@@ -466,6 +816,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -476,8 +835,28 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "notify-rust"
+version = "4.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ff2e74231b72c832d82982193b417f230945be6bdb5575b251d941d31adb00"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -486,6 +865,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -499,6 +917,22 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -530,12 +964,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -546,6 +1087,27 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
@@ -583,7 +1145,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror",
 ]
@@ -598,20 +1160,20 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -633,19 +1195,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -696,6 +1298,18 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -749,6 +1363,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +1408,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,8 +1434,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -790,6 +1448,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,9 +1465,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.11",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -808,6 +1496,48 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -845,10 +1575,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -909,6 +1674,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1730,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,9 +1759,20 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -972,12 +1804,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -986,7 +1834,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -996,6 +1844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1012,6 +1869,24 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1069,4 +1944,214 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.23"
 notify-rust = "4.17.0"
 cron = "0.16.0"
+zbus = "5.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,5 @@ dirs = "6.0.0"
 ratatui = "0.29.0"
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.23"
+notify-rust = "4.17.0"
+cron = "0.16.0"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ Instead of streaks, Flow State tracks weekly patterns.
 - **Struggling** (2): Frequent relapse
 - **Chaotic** (1): Inconsistent
 
+## Notification system
+
+Notifications are a double-edged sword for people with ADHD - we need them to avoid forgetting important things, but 
+when we're juggling multiple tasks in a busy life, they tend to overwhelm our neurodivergent brains.
+
+That's why the notification system in flow_state is designed to avoid throwing useless data at you. In the config
+file `.config/flow_state/notification.toml`, you can set up a daily reminder. This reminder will fire at a time
+defined by keys `hour` and `minute`, once a day. But it will only fire in two circumstances:
+- when you've forgotten to check your tracker entirely, a non-judgmental message will remind you to take a look.
+  This is going to fire only when your task completion percentage is under a set threshold `low_threshold`.
+- when you've done exceptionally well, a cheering message will give you some encouragement for knocking it out of
+  the park. This is as a reward counterbalance to the reminder message. This will fire when your task completion is
+  above `high_threshold`.
+
+As a result, there will be no alerts on most days you actually check off things on the tracker, when your
+completion isn't near zero or near perfect. But you will receive a single reminder if you've forgotten to look at your
+tasks, and some well-deserved congrats for doing well.
+
+Neurodivergent-friendly defaults for notifications are in example file `config/notification.toml`. Without this file with
+key `enable` set to `true`, the notifications are off - before enabling them, make sure they are useful for your
+particular neurodivergent brain.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A terminal-based habit tracker designed for neurodivergent users. Focuses on pro
 - **Dual habit types**: Track habits to build and habits to avoid
 - **Minimal interface**: Keyboard-driven with essential information only
 - **Local storage**: All data stored locally using TOML files
+- **Optional notifications**: Made to avoid alert fatigue while still providing a reminder
 
 ## Design Philosophy
 
@@ -97,7 +98,6 @@ Contributions welcome, especially from neurodivergent developers who understand 
 - ADHD-friendly UX enhancements
 - Performance optimizations
 - Cross-platform compatibility
-
 
 ## Acknowledgments
 

--- a/config/notification.toml
+++ b/config/notification.toml
@@ -1,13 +1,17 @@
+# Put this in ~/.config/flow_state/notification.toml
+
 # people with ADHD should be careful with notifications. 
 # That's why this can fire only once a day.
 # Enable with caution.
 enable = true
+
 # To avoid alert fatigue, it's best to not always have
 # the notification pop. It should only fire if you
 # completely forgot to check the tracker.
 # The low threshold value is the percentage of done tasks
-# below which it will fire at.
-low_threshold = 20
+# at or below which it will fire at.
+low_threshold = 10
+
 # To balance out the annoying alert when you don't do well,
 # you might want to have a 'reward' mechanism alert. This
 # isn't a streak - so don't be discouraged if you don't get it! -
@@ -15,7 +19,8 @@ low_threshold = 20
 # when you're really knocking it out of the park.
 # This high threshold value is the percentage of done tasks
 # above which it will fire. Good job!
-high_threshold = 90
+high_threshold = 80
+
 # hour to notify at
 hour = 20
 # minute to notify at

--- a/config/notification.toml
+++ b/config/notification.toml
@@ -1,0 +1,22 @@
+# people with ADHD should be careful with notifications. 
+# That's why this can fire only once a day.
+# Enable with caution.
+enable = true
+# To avoid alert fatigue, it's best to not always have
+# the notification pop. It should only fire if you
+# completely forgot to check the tracker.
+# The low threshold value is the percentage of done tasks
+# below which it will fire at.
+low_threshold = 20
+# To balance out the annoying alert when you don't do well,
+# you might want to have a 'reward' mechanism alert. This
+# isn't a streak - so don't be discouraged if you don't get it! -
+# but it's something to get a bit of dopamine
+# when you're really knocking it out of the park.
+# This high threshold value is the percentage of done tasks
+# above which it will fire. Good job!
+high_threshold = 90
+# hour to notify at
+hour = 20
+# minute to notify at
+minute = 0

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::io;
+use std::sync::{Arc, Mutex};
 
 use chrono::{Datelike, Duration, Utc};
 
@@ -57,6 +58,41 @@ pub enum ScreenMode {
     Reset,
 }
 
+#[derive(Clone)]
+pub struct Notif {
+    pub done: usize,
+    pub total: usize,
+}
+
+impl Default for Notif {
+    fn default() -> Self {
+        Notif {
+            done: 0,
+            total: 0,
+        }
+    }
+}
+
+impl Notif {
+    pub fn get_percent(&self) -> f32 {
+        if self.total == 0 {
+            return 100.0;
+        }
+        return 100.0 * (self.done as f32) / (self.total as f32);
+    }
+
+    pub fn get_notification_text(&self) -> String {
+        let progress = self.get_percent();
+        if progress <= 20.0 {
+            return String::from("Have you checked your habit tracker today? No tasks have been done.");
+        } else if progress >= 80.0 {
+            return String::from("You've done nearly all your tasks today, well done!");
+        } else {
+            return String::from("");
+        }
+    }
+}
+
 pub struct Counter {
     pub build_counter: usize,
     pub avoid_counter: usize,
@@ -84,6 +120,7 @@ pub struct App {
     pub screen_mode: ScreenMode,
     pub current_habit: Habit,
     pub current_day: Day,
+    pub notif: Arc<Mutex<Notif>>,
 }
 
 impl App {
@@ -97,6 +134,7 @@ impl App {
             screen_mode: ScreenMode::Normal,
             current_day: Day::Today,
             current_habit: Habit::default(),
+            notif: Arc::new(Mutex::new(Notif::default())),
         }
     }
 
@@ -306,6 +344,7 @@ impl App {
     }
 
     fn display_gauge(&self, progress: f32) -> String {
+        self.set_todays_progress();
         let segments = [
             "▱▱▱▱▱▱▱▱▱▱", // 0%
             "▰▱▱▱▱▱▱▱▱▱", // 10%
@@ -323,12 +362,23 @@ impl App {
         format!("{} {:.1}%", segments[index], progress)
     }
 
+    pub fn set_todays_progress(&self) {
+        let total = self.build_habits.len() + self.avoid_habits.len();
+        let date = Day::Today.resolve_date();
+        let completed = self.count_completed_on(date);
+
+        {
+            let mut notif = self.notif.lock().unwrap();
+            (*notif).done = completed;
+            (*notif).total = total;
+        }
+    }
+
     pub fn check_todays_progress(&self, day: &Day) -> String {
         let total = self.build_habits.len() + self.avoid_habits.len();
         if total == 0 {
             return format!("{}  ({}/{})", self.display_gauge(0.0), 0, total);
         }
-
         let date = day.resolve_date();
         let completed = self.count_completed_on(date);
         let progress = (completed as f32 / total as f32) * 100.0;
@@ -339,7 +389,7 @@ impl App {
             total
         )
     }
-
+    
     pub fn check_weeks_progress(&self) -> String {
         let total_habits = self.build_habits.len() + self.avoid_habits.len();
         if total_habits == 0 {

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 use chrono::{Datelike, Duration, Utc};
 
 use crate::habit::{Day, Habit, HabitType};
-use crate::storage;
+use crate::storage::{self, NotificationSettings};
 
 #[derive(Debug)]
 
@@ -59,21 +59,25 @@ pub enum ScreenMode {
 }
 
 #[derive(Clone)]
-pub struct Notif {
+pub struct NotificationData {
     pub done: usize,
     pub total: usize,
+    pub low_threshold: usize,
+    pub high_threshold: usize,
 }
 
-impl Default for Notif {
+impl Default for NotificationData {
     fn default() -> Self {
-        Notif {
+        NotificationData {
             done: 0,
             total: 0,
+            low_threshold: 20,
+            high_threshold: 80,
         }
     }
 }
 
-impl Notif {
+impl NotificationData {
     pub fn get_percent(&self) -> f32 {
         if self.total == 0 {
             return 100.0;
@@ -83,9 +87,9 @@ impl Notif {
 
     pub fn get_notification_text(&self) -> String {
         let progress = self.get_percent();
-        if progress <= 20.0 {
-            return String::from("Have you checked your habit tracker today? No tasks have been done.");
-        } else if progress >= 80.0 {
+        if progress <= self.low_threshold as f32 {
+            return String::from("Have you checked your habit tracker today? Very few tasks have been done.");
+        } else if progress >= self.high_threshold as f32 {
             return String::from("You've done nearly all your tasks today, well done!");
         } else {
             return String::from("");
@@ -120,7 +124,7 @@ pub struct App {
     pub screen_mode: ScreenMode,
     pub current_habit: Habit,
     pub current_day: Day,
-    pub notif: Arc<Mutex<Notif>>,
+    pub notif: Arc<Mutex<NotificationData>>,
 }
 
 impl App {
@@ -134,8 +138,14 @@ impl App {
             screen_mode: ScreenMode::Normal,
             current_day: Day::Today,
             current_habit: Habit::default(),
-            notif: Arc::new(Mutex::new(Notif::default())),
+            notif: Arc::new(Mutex::new(NotificationData::default())),
         }
+    }
+
+    pub fn set_notifications(&mut self, settings: NotificationSettings) {
+        let mut notif = self.notif.lock().unwrap();
+        (*notif).low_threshold = settings.low_threshold;
+        (*notif).high_threshold = settings.high_threshold;
     }
 
     pub fn load_habits(&mut self) -> Result<(), AppError> {
@@ -344,7 +354,6 @@ impl App {
     }
 
     fn display_gauge(&self, progress: f32) -> String {
-        self.set_todays_progress();
         let segments = [
             "▱▱▱▱▱▱▱▱▱▱", // 0%
             "▰▱▱▱▱▱▱▱▱▱", // 10%
@@ -362,7 +371,7 @@ impl App {
         format!("{} {:.1}%", segments[index], progress)
     }
 
-    pub fn set_todays_progress(&self) {
+    pub fn set_notification(&self) {
         let total = self.build_habits.len() + self.avoid_habits.len();
         let date = Day::Today.resolve_date();
         let completed = self.count_completed_on(date);
@@ -376,6 +385,7 @@ impl App {
 
     pub fn check_todays_progress(&self, day: &Day) -> String {
         let total = self.build_habits.len() + self.avoid_habits.len();
+        self.set_notification();
         if total == 0 {
             return format!("{}  ({}/{})", self.display_gauge(0.0), 0, total);
         }
@@ -396,6 +406,7 @@ impl App {
             return format!("{}  ({}/{})", self.display_gauge(0.0), 0, 0);
         }
 
+        self.set_notification();
         let today = Utc::now();
         let date = today.date_naive();
         let days_since_monday = today.weekday().num_days_from_monday();

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use chrono::{Datelike, Duration, Utc};
 
 use crate::habit::{Day, Habit, HabitType};
 use crate::storage::{self, NotificationSettings};
+use crate::notifications::NotificationData;
 
 #[derive(Debug)]
 
@@ -58,44 +59,6 @@ pub enum ScreenMode {
     Reset,
 }
 
-#[derive(Clone)]
-pub struct NotificationData {
-    pub done: usize,
-    pub total: usize,
-    pub low_threshold: usize,
-    pub high_threshold: usize,
-}
-
-impl Default for NotificationData {
-    fn default() -> Self {
-        NotificationData {
-            done: 0,
-            total: 0,
-            low_threshold: 20,
-            high_threshold: 80,
-        }
-    }
-}
-
-impl NotificationData {
-    pub fn get_percent(&self) -> f32 {
-        if self.total == 0 {
-            return 100.0;
-        }
-        return 100.0 * (self.done as f32) / (self.total as f32);
-    }
-
-    pub fn get_notification_text(&self) -> String {
-        let progress = self.get_percent();
-        if progress <= self.low_threshold as f32 {
-            return String::from("Have you checked your habit tracker today? Very few tasks have been done.");
-        } else if progress >= self.high_threshold as f32 {
-            return String::from("You've done nearly all your tasks today, well done!");
-        } else {
-            return String::from("");
-        }
-    }
-}
 
 pub struct Counter {
     pub build_counter: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,14 @@
 use std::io::{self, Result};
+use std::sync::{Arc};
+use std::thread;
+use std::time::Duration;
+use std::str::FromStr;
+use chrono::Utc;
+
+use notify_rust::Notification;
+use cron::Schedule;
+use cron::ScheduleIterator;
+use std::iter::Peekable;
 
 use ratatui::{
     backend::CrosstermBackend,
@@ -17,6 +27,7 @@ mod storage;
 mod ui;
 
 use crate::app::App;
+use crate::app::Notif;
 
 fn main() -> Result<()> {
 
@@ -31,6 +42,17 @@ fn main() -> Result<()> {
         eprintln!("Warning: Failed to load habits: {}", e);
     }
 
+    let app_clone = Arc::clone(&app.notif);
+    thread::spawn(move || {
+        let expression = "0 0 20 * * * *";
+        let schedule = Schedule::from_str(expression).unwrap();
+        let mut iterator = schedule.upcoming(Utc).peekable();
+        loop {
+            thread::sleep(Duration::from_millis(60000));
+            check_notification_trigger(app_clone.lock().unwrap().clone(), &mut iterator);
+        }
+    });
+
     input::run_app(&mut terminal, &mut app)?;
 
     disable_raw_mode()?;
@@ -43,3 +65,28 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+pub fn check_notification_trigger(count: Notif, iter: &mut Peekable<ScheduleIterator<'_, Utc>>) {
+    let datetime = iter.peek();
+    let now = Utc::now();
+    match datetime {
+        Some(x) => if *x <= now {
+            send_notification(count);
+            iter.next();
+        }
+        // The division was invalid
+        None    => {},
+    }
+}
+
+pub fn send_notification(count: Notif) {
+    let s = count.get_notification_text();
+    if !s.is_empty() {
+        let _ = Notification::new().summary("flow_state for today")
+            .body(&s[..])
+            .icon("firefox")
+            .show();
+    }
+}
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,9 @@ use std::sync::{Arc};
 use std::thread;
 use std::time::Duration;
 use std::str::FromStr;
-use chrono::Utc;
+use chrono::Local;
 
-use notify_rust::Notification;
 use cron::Schedule;
-use cron::ScheduleIterator;
-use std::iter::Peekable;
 
 use ratatui::{
     backend::CrosstermBackend,
@@ -25,9 +22,9 @@ mod habit;
 mod input;
 mod storage;
 mod ui;
+mod notifications;
 
 use crate::app::App;
-use crate::app::Notif;
 
 fn main() -> Result<()> {
 
@@ -42,16 +39,29 @@ fn main() -> Result<()> {
         eprintln!("Warning: Failed to load habits: {}", e);
     }
 
-    let app_clone = Arc::clone(&app.notif);
-    thread::spawn(move || {
-        let expression = "0 0 20 * * * *";
-        let schedule = Schedule::from_str(expression).unwrap();
-        let mut iterator = schedule.upcoming(Utc).peekable();
-        loop {
-            thread::sleep(Duration::from_millis(60000));
-            check_notification_trigger(app_clone.lock().unwrap().clone(), &mut iterator);
-        }
-    });
+    let notification_settings = storage::load_notification_settings();
+
+    match notification_settings {
+        Err(ref e) => eprintln!("Warning: Failed to load notification settings: {}", e),
+        Ok(_) => {},
+    }
+
+    let notifications = notification_settings.unwrap();
+    app.set_notifications(notifications.clone());
+
+    if notifications.enable {
+        let app_clone = Arc::clone(&app.notif);
+
+        thread::spawn(move || {
+            let expression = format!("0 {} {} * * * *", notifications.minute, notifications.hour);
+            let schedule = Schedule::from_str(&expression).unwrap();
+            let mut iterator = schedule.upcoming(Local).peekable();
+            loop {
+                thread::sleep(Duration::from_secs(1));
+                notifications::check_notification_trigger(app_clone.lock().unwrap().clone(), &mut iterator);
+            }
+        });
+    }
 
     input::run_app(&mut terminal, &mut app)?;
 
@@ -65,28 +75,4 @@ fn main() -> Result<()> {
 
     Ok(())
 }
-
-pub fn check_notification_trigger(count: Notif, iter: &mut Peekable<ScheduleIterator<'_, Utc>>) {
-    let datetime = iter.peek();
-    let now = Utc::now();
-    match datetime {
-        Some(x) => if *x <= now {
-            send_notification(count);
-            iter.next();
-        }
-        // The division was invalid
-        None    => {},
-    }
-}
-
-pub fn send_notification(count: Notif) {
-    let s = count.get_notification_text();
-    if !s.is_empty() {
-        let _ = Notification::new().summary("flow_state for today")
-            .body(&s[..])
-            .icon("firefox")
-            .show();
-    }
-}
-
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
             let schedule = Schedule::from_str(&expression).unwrap();
             let mut iterator = schedule.upcoming(Local).peekable();
             loop {
-                thread::sleep(Duration::from_secs(1));
+                thread::sleep(Duration::from_secs(30));
                 notifications::check_notification_trigger(app_clone.lock().unwrap().clone(), &mut iterator);
             }
         });

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -4,7 +4,44 @@ use notify_rust::Notification;
 use cron::ScheduleIterator;
 use std::iter::Peekable;
 
-use crate::app::NotificationData;
+#[derive(Clone)]
+pub struct NotificationData {
+    pub done: usize,
+    pub total: usize,
+    pub low_threshold: usize,
+    pub high_threshold: usize,
+}
+
+impl Default for NotificationData {
+    fn default() -> Self {
+        NotificationData {
+            done: 0,
+            total: 0,
+            low_threshold: 20,
+            high_threshold: 80,
+        }
+    }
+}
+
+impl NotificationData {
+    pub fn get_percent(&self) -> f32 {
+        if self.total == 0 {
+            return 100.0;
+        }
+        return 100.0 * (self.done as f32) / (self.total as f32);
+    }
+
+    pub fn get_notification_text(&self) -> String {
+        let progress = self.get_percent();
+        if progress <= self.low_threshold as f32 {
+            return String::from("I know you're busy, but make sure to check your habit tracker today!");
+        } else if progress >= self.high_threshold as f32 {
+            return String::from("You've done nearly all your tasks today, well done!");
+        } else {
+            return String::from("");
+        }
+    }
+}
 
 pub fn check_notification_trigger(count: NotificationData, iter: &mut Peekable<ScheduleIterator<'_, Local>>) {
     let datetime = iter.peek();

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -1,0 +1,32 @@
+use chrono::Local;
+
+use notify_rust::Notification;
+use cron::ScheduleIterator;
+use std::iter::Peekable;
+
+use crate::app::NotificationData;
+
+pub fn check_notification_trigger(count: NotificationData, iter: &mut Peekable<ScheduleIterator<'_, Local>>) {
+    let datetime = iter.peek();
+    let now = Local::now();
+    match datetime {
+        Some(x) => if *x <= now {
+            send_notification(count);
+            iter.next();
+        }
+        None    => {},
+    }
+}
+
+pub fn send_notification(count: NotificationData) {
+    let s = count.get_notification_text();
+    if !s.is_empty() {
+        let _ = Notification::new().summary("flow_state reminder")
+            .body(&s[..])
+            .timeout(0)
+            .urgency(notify_rust::Urgency::Normal)
+            .show();
+    }
+}
+
+

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,6 +13,15 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Clone)]
+pub struct NotificationSettings {
+    pub enable: bool,
+    pub hour: usize,
+    pub minute: usize,
+    pub low_threshold: usize,
+    pub high_threshold: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 struct HabitsData {
     build_habits: Vec<Habit>,
     avoid_habits: Vec<Habit>,
@@ -86,4 +95,31 @@ fn populate_dummy_data() -> (Vec<Habit>, Vec<Habit>) {
         },
     ];
     (build_habits, avoid_habits)
+}
+
+pub fn load_notification_settings() -> Result<NotificationSettings, AppError> {
+    let config_dir = match dirs::config_dir(){
+        Some(path)=>Ok(path.join("flow_state")) ,
+        None => Err(io::Error::new(io::ErrorKind::NotFound, "config directory not found"))
+    }?;
+
+    let notification_file = config_dir.join("notification.toml");
+
+    if notification_file.exists() {
+        let content = read_to_string(notification_file)?;
+        let notification_data: NotificationSettings = toml::from_str(&content)?;
+        Ok(notification_data)
+    } else {
+        Ok(default_notification_settings())
+    }
+}
+
+fn default_notification_settings() -> NotificationSettings {
+    NotificationSettings {
+        enable: false,
+        hour: 0,
+        minute: 0,
+        low_threshold: 20,
+        high_threshold: 80,
+    }
 }


### PR DESCRIPTION
As a neurodivergent user, I often found myself forgetting to even take a peek at my tracker. If this happened multiple days in a row I started to have real problems getting back to the grind.

Therefore, I have added a notification system. But rest assured, I know all about alert fatigue. So here's how it works:

There's only one notification a day. It only happens at a predetermined time of the day. But it doesn't pester you with saying the exact percentage or always firing: it only goes off when you've genuinely not set off anything on the tracker, indicating you've probably forgotten. You can set a percentage threshold for this.

To balance this annoyance I've added a bit of a dopamine hit, too: if you've marked almost everything, the notification is an atta-boy to encourage you a little.

Sane defaults for neurodivergent people are provided in the file config/notification.toml. Without this file in the config dir, no notifications will fire by default. The example file fires the reminder when under 10% completed and shows the atta-boy at above 80% completed. It shuts up in the middle, so on most days it stays silent.

I don't write Rust so this is probably some shambolic Rust but it seems to work well.

Uses the cross-platform notification library so it should work everywhere a notification displayer is installed.